### PR TITLE
Illustration how azure additions to OAI can be modeled in TypeSpec

### DIFF
--- a/azure.js
+++ b/azure.js
@@ -1,0 +1,11 @@
+export function $azureCustomizations(context, target, additions) {
+    for (const [key, def] of additions.properties) {
+        const type = def.type;
+        if ("kind" in type && type.kind === "Intrinsic" && type.name === "void") {
+            target.properties.delete(key);
+        }
+        else {
+            target.properties.set(key, def);
+        }
+    }
+}

--- a/azure.tsp
+++ b/azure.tsp
@@ -1,0 +1,17 @@
+import "./main.tsp";
+import "./azure.js";
+
+extern dec azureCustomizations(target: TypeSpec.Reflection.Model, agmentWith: TypeSpec.Reflection.Model);
+
+
+@@azureCustomizations(OpenAI.CreateChatCompletionRequest, {
+    // Azure doesn't support the `model` parameter
+    // Note: we could use `never` for this as well... thoughts?
+    `model`: void;
+
+    /**
+     * The data that the model will use to generate the completion.
+     * Bla, bla, bla...
+     */
+    on_your_data?: string;
+});


### PR DESCRIPTION
Example/stub of a "model merge" decorator that can be used to model the delta between AOAI and OAI. 
